### PR TITLE
Add devtools support

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
+const args = require('minimist')(process.argv.slice(2))
 
-require('./').attach(process.argv[2])
+require('./').attach(args._[0], args)

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ const sodium = require('sodium-universal')
 const repl = require('repl')
 const os = require('os')
 const path = require('path')
+const net = require('net')
+const process = require('process')
 
-module.exports = function replSwarm ({ seed, ...context } = {}) {
+module.exports = function replSwarm ({ seed, devtools, ...context } = {}) {
   const node = new DHT({ ephemeral: true })
 
   if (!seed) seed = process.env.REPL_SWARM || randomBytes(32)
@@ -12,50 +14,22 @@ module.exports = function replSwarm ({ seed, ...context } = {}) {
 
   const keyPair = DHT.keyPair(seed)
 
-  const tmp = path.join(os.tmpdir(), 'repl-swarm-' + keyPair.publicKey.toString('hex'))
-
-  const server = node.createServer({ firewall }, function (socket) {
-    console.error('[repl-swarm] Attaching repl session')
-
-    socket.setTimeout(30000)
-    socket.setKeepAlive(20000)
-
-    const prompt = '[' + seed.subarray(0, 4).toString('hex') + ']> '
-
-    const r = repl.start({
-      useColors: true,
-      prompt,
-      input: socket,
-      output: socket,
-      terminal: true,
-      preview: false
-    })
-
-    r.on('exit', function () {
-      socket.end()
-    })
-
-    r.on('error', function () {
-      socket.destroy()
-    })
-
-    r.setupHistory(tmp, () => {})
-
-    for (const key of Object.keys(context)) {
-      r.context[key] = context[key]
+  const server = node.createServer({ firewall, reusableSocket: true }, function (socket) {
+    if (devtools) {
+      listenDevtools(socket, context)
+    } else {
+      listenRepl(seed, keyPair, socket, context)
     }
-
-    socket.on('end', () => socket.end())
-    socket.on('error', () => socket.destroy())
-    socket.on('close', function () {
-      console.error('[repl-swarm] Session closed')
-    })
   })
-
   server.listen(keyPair)
 
   const hexSeed = seed.toString('hex')
-  console.error('[repl-swarm] Repl attached. To connect to it run:\n             repl-swarm ' + hexSeed)
+  if (devtools) {
+    console.error('[repl-swarm] Listening for devtools. To connect to it run:\n             repl-swarm ' + hexSeed + ' --devtools\n')
+    console.error('             Then open Chrome devtools and connect to the Node process')
+  } else {
+    console.error('[repl-swarm] Repl attached. To connect to it run:\n             repl-swarm ' + hexSeed)
+  }
 
   function firewall (remotePublicKey) {
     return !remotePublicKey.equals(keyPair.publicKey)
@@ -64,7 +38,7 @@ module.exports = function replSwarm ({ seed, ...context } = {}) {
   return hexSeed
 }
 
-module.exports.attach = function (seed) {
+module.exports.attach = function (seed, { devtools = false } = {}) {
   if (!seed) seed = process.env.REPL_SWARM
   if (typeof seed === 'string') seed = Buffer.from(seed, 'hex')
   if (!seed) throw new Error('Seed is required')
@@ -72,15 +46,55 @@ module.exports.attach = function (seed) {
   const node = new DHT({ ephemeral: true })
   const keyPair = DHT.keyPair(seed)
 
-  const socket = node.connect(keyPair.publicKey, { keyPair })
+  if (devtools) {
+    attachDevtools(node, keyPair)
+  } else {
+    attachRepl(node, keyPair)
+  }
+}
 
+function listenRepl (seed, keyPair, socket, context) {
+  socket.on('end', () => socket.end())
+  socket.on('error', (err) => { console.log('err:', err); socket.destroy() })
+  socket.on('close', function () {
+    console.error('[repl-swarm] Session closed')
+  })
+
+  const tmp = path.join(os.tmpdir(), 'repl-swarm-' + keyPair.publicKey.toString('hex'))
+  const prompt = '[' + seed.subarray(0, 4).toString('hex') + ']> '
+
+  const r = repl.start({
+    useColors: true,
+    prompt,
+    input: socket,
+    output: socket,
+    terminal: true,
+    preview: false
+  })
+
+  r.on('exit', function () {
+    socket.end()
+  })
+
+  r.on('error', function () {
+    socket.destroy()
+  })
+
+  r.setupHistory(tmp, () => {})
+
+  for (const key of Object.keys(context)) {
+    r.context[key] = context[key]
+  }
+}
+
+function attachRepl (node, keyPair) {
+  const socket = node.connect(keyPair.publicKey, { keyPair })
   socket.setTimeout(30000)
   socket.setKeepAlive(20000)
 
   socket.pipe(process.stdout)
 
   socket.on('end', () => socket.end())
-
   socket.once('data', function () {
     process.stdin.setRawMode(true)
     process.stdin.pipe(socket)
@@ -99,8 +113,45 @@ module.exports.attach = function (seed) {
   })
 }
 
+function listenDevtools (socket, context) {
+  global.context = context
+  process.kill(process.pid, 'SIGUSR1')
+
+  const tcp = net.connect(9229, '127.0.0.1', onconnect)
+
+  function onconnect () {
+    socket.pipe(tcp).pipe(socket)
+    socket.on('close', () => tcp.destroy())
+    tcp.on('close', () => socket.destroy())
+    socket.on('error', noop)
+    tcp.on('error', noop)
+  }
+}
+
+function attachDevtools (node, keyPair) {
+  const server = net.createServer(onconnection)
+
+  server.listen(9229)
+  console.log('Open devtools to connect...')
+
+  function onconnection (tcp) {
+    const socket = node.connect(keyPair.publicKey, { keyPair })
+    socket.setTimeout(30000)
+    socket.setKeepAlive(20000)
+
+    socket.pipe(tcp).pipe(socket)
+
+    socket.on('close', () => tcp.destroy())
+    tcp.on('close', () => socket.destroy())
+    socket.on('error', noop)
+    tcp.on('error', noop)
+  }
+}
+
 function randomBytes (length) {
   const buffer = Buffer.alloc(length)
   sodium.randombytes_buf(buffer)
   return buffer
 }
+
+function noop () {}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "hyperdht": "^6.6.0",
+    "minimist": "^1.2.8",
     "sodium-universal": "^4.0.0"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/holepunchto/repl-swarm.git"


### PR DESCRIPTION
Proxies the devtools protocol so if you do `repl({ devtools: true, ...context })` and then `repl-swarm <key> --devtools`, you can open devtools and attach to the process.

In devtools mode, the `context` will be set on `global`. 